### PR TITLE
Added the ConsentForm

### DIFF
--- a/Service/Appointment/IntakeFormService.go
+++ b/Service/Appointment/IntakeFormService.go
@@ -102,6 +102,7 @@ func AddIntakeFormService(db *gorm.DB, reqVal model.AddIntakeFormReq, idValue in
 	UpdateAppointmenterr := tx.Exec(
 		query.UpdateAppointment,
 		reqVal.CategoryId,
+		reqVal.Consent,
 		reqVal.AppointmentId,
 	).Error
 	if UpdateAppointmenterr != nil {

--- a/Service/UserService/WellthgreenFormsService.go
+++ b/Service/UserService/WellthgreenFormsService.go
@@ -1,0 +1,386 @@
+package service
+
+import (
+	logger "AuthenticationService/internal/Helper/Logger"
+	model "AuthenticationService/internal/Model/UserService"
+	query "AuthenticationService/query/UserService"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+func ListPatientConsentService(db *gorm.DB, reqVal model.ListPatientConsentReq) []model.ListPatientConsent {
+	log := logger.InitLogger()
+
+	var ListPatient []model.ListPatientConsent
+	if err := db.Raw(query.ListPatientConsentSQL, reqVal.ScanCenterId).Scan(&ListPatient).Error; err != nil {
+		log.Error("Error fetching WG brochure: " + err.Error())
+		return []model.ListPatientConsent{}
+	}
+
+	return ListPatient
+}
+
+func ListPatientBrochureService(db *gorm.DB, reqVal model.ListPatientBrochureReq, wgDataForm int, scDataForm int) model.ListPatientBrochureRes {
+	log := logger.InitLogger()
+
+	var res model.ListPatientBrochureRes
+	res.Status = true
+	res.SCBrochureAccessStatus = true
+
+	// WG Patient Brochure
+	var wgBrochures []model.ListWGPatientBrochureModel
+	if err := db.Raw(query.ListWGPatientBrochureSQL, wgDataForm).Scan(&wgBrochures).Error; err != nil {
+		log.Error("Error fetching WG brochure: " + err.Error())
+		res.Status = false
+		return res
+	}
+	if len(wgBrochures) > 0 {
+		res.WGPatientBrochure = wgBrochures[0].FDData
+	}
+
+	// SC Patient Brochure
+	var scBrochures []model.ListWGPatientBrochureModel
+	if err := db.Raw(query.ListSCPatientBrochureSQL, scDataForm, reqVal.ScancenterId).Scan(&scBrochures).Error; err != nil {
+		log.Error("Error fetching SC brochure: " + err.Error())
+		res.Status = false
+		return res
+	}
+	fmt.Println(scBrochures, scDataForm, reqVal.ScancenterId)
+	if len(scBrochures) > 0 {
+		res.SCBrochureAccessStatus = scBrochures[0].FDAccessData
+		res.SCPatientBrochure = scBrochures[0].FDData
+	}
+
+	return res
+}
+
+func UpdatePatientBrochureService(db *gorm.DB, reqVal model.UpdatePatientBroucherReq, idValue int, wgDataForm int, scDataForm int, wgTransactionId int, scTransactionId int) model.UpdatePatientBroucherResponse {
+	log := logger.InitLogger()
+
+	tx := db.Begin()
+	if tx.Error != nil {
+		log.Printf("ERROR: Failed to begin transaction: %v\n", tx.Error)
+		return model.UpdatePatientBroucherResponse{
+			Status:  false,
+			Message: "Something Went Wrong, Try Again",
+		}
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("ERROR: Recovered from panic, rolling back transaction:", r)
+			tx.Rollback()
+		}
+	}()
+
+	if reqVal.ScancenterId == 0 { //Wellthgreen Patient Brochure need to Handle
+		var wgBrochures []model.ListWGPatientBrochureModel
+		if err := tx.Raw(query.ListWGPatientBrochureSQL, wgDataForm).Scan(&wgBrochures).Error; err != nil {
+			log.Error("Error fetching WG brochure: " + err.Error())
+			return model.UpdatePatientBroucherResponse{
+				Status:  false,
+				Message: "Something Went Wrong, Try Again",
+			}
+		}
+
+		if len(wgBrochures) > 0 { //Need to Update the Brochure
+			UpdateWGBrochureErr := tx.Exec(query.UpdateWGPatientBrochureSQL, reqVal.Brochure, wgDataForm).Error
+			if UpdateWGBrochureErr != nil {
+				log.Error("Error updating WG brochure: " + UpdateWGBrochureErr.Error())
+				return model.UpdatePatientBroucherResponse{
+					Status:  false,
+					Message: "Something Went Wrong, Try Again",
+				}
+			}
+
+			errTrans := tx.Exec(query.InsertTransactionDataSQL, wgTransactionId, wgDataForm, int(idValue), `["Wellthgreen Patient Brochure Updated!"]`).Error
+			if errTrans != nil {
+				log.Printf("ERROR: Failed to Transaction History: %v\n", errTrans)
+				tx.Rollback()
+				return model.UpdatePatientBroucherResponse{
+					Status:  false,
+					Message: "Something Went Wrong, Try Again",
+				}
+			}
+
+		} else { //Need to Add the Brochure
+			AddWGBrochureErr := tx.Exec(query.InsertWGPatientBrochureSQL, wgDataForm, reqVal.Brochure).Error
+			if AddWGBrochureErr != nil {
+				log.Error("Error adding WG brochure: " + AddWGBrochureErr.Error())
+				return model.UpdatePatientBroucherResponse{
+					Status:  false,
+					Message: "Something Went Wrong, Try Again",
+				}
+			}
+
+			errTrans := tx.Exec(query.InsertTransactionDataSQL, wgTransactionId, wgDataForm, int(idValue), `["Wellthgreen Patient Brochure Added!"]`).Error
+			if errTrans != nil {
+				log.Printf("ERROR: Failed to Transaction History: %v\n", errTrans)
+				tx.Rollback()
+				return model.UpdatePatientBroucherResponse{
+					Status:  false,
+					Message: "Something Went Wrong, Try Again",
+				}
+			}
+		}
+
+	} else { //Scan Center Patient Brochure need to Handle
+		var scBrochures []model.ListWGPatientBrochureModel
+		if err := tx.Raw(query.ListSCPatientBrochureSQL, scDataForm, reqVal.ScancenterId).Scan(&scBrochures).Error; err != nil {
+			log.Error("Error fetching SC brochure: " + err.Error())
+			return model.UpdatePatientBroucherResponse{
+				Status:  false,
+				Message: "Something Went Wrong, Try Again",
+			}
+		}
+
+		if len(scBrochures) > 0 { //Need to Update the Brochure
+			UpdatescBrochureErr := tx.Exec(
+				query.UpdatescPatientBrochureSQL,
+				reqVal.Brochure,
+				reqVal.AccessStatus,
+				scDataForm,
+				reqVal.ScancenterId,
+			).Error
+			if UpdatescBrochureErr != nil {
+				log.Error("Error updating SC brochure: " + UpdatescBrochureErr.Error())
+				return model.UpdatePatientBroucherResponse{
+					Status:  false,
+					Message: "Something Went Wrong, Try Again",
+				}
+			}
+
+			errTrans := tx.Exec(query.InsertTransactionDataSQL, scTransactionId, reqVal.ScancenterId, int(idValue), `["Scan Center Patient Brochure Updated!"]`).Error
+			if errTrans != nil {
+				log.Printf("ERROR: Failed to Transaction History: %v\n", errTrans)
+				tx.Rollback()
+				return model.UpdatePatientBroucherResponse{
+					Status:  false,
+					Message: "Something Went Wrong, Try Again",
+				}
+			}
+		} else { // Need to Add the Brochure
+			AddscBrochureErr := tx.Exec(
+				query.InsertscPatientBrochureSQL,
+				scDataForm,
+				reqVal.ScancenterId,
+				reqVal.Brochure,
+				reqVal.AccessStatus,
+			).Error
+			if AddscBrochureErr != nil {
+				log.Error("Error adding SC brochure: " + AddscBrochureErr.Error())
+				return model.UpdatePatientBroucherResponse{
+					Status:  false,
+					Message: "Something Went Wrong, Try Again",
+				}
+			}
+
+			errTrans := tx.Exec(query.InsertTransactionDataSQL, scTransactionId, reqVal.ScancenterId, int(idValue), `["Scan Center Patient Brochure Updated!"]`).Error
+			if errTrans != nil {
+				log.Printf("ERROR: Failed to Transaction History: %v\n", errTrans)
+				tx.Rollback()
+				return model.UpdatePatientBroucherResponse{
+					Status:  false,
+					Message: "Something Went Wrong, Try Again",
+				}
+			}
+		}
+
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		log.Printf("ERROR: Failed to commit transaction: %v\n", err)
+		tx.Rollback()
+		return model.UpdatePatientBroucherResponse{
+			Status:  false,
+			Message: "Something Went Wrong, Try Again",
+		}
+	}
+
+	return model.UpdatePatientBroucherResponse{
+		Status:  true,
+		Message: "Successfully Updated the Brochure",
+	}
+}
+
+// func ListPatientConsentService(db *gorm.DB, reqVal model.ListPatientBrochureReq) model.ListPatientBrochureRes {
+// 	log := logger.InitLogger()
+
+// 	var res model.ListPatientBrochureRes
+// 	res.Status = true
+
+// 	// WG Patient Brochure
+// 	var wgBrochures []model.ListWGPatientBrochureModel
+// 	if err := db.Raw(query.ListWGPatientBrochureSQL, 3).Scan(&wgBrochures).Error; err != nil {
+// 		log.Error("Error fetching WG brochure: " + err.Error())
+// 		res.Status = false
+// 		return res
+// 	}
+// 	if len(wgBrochures) > 0 {
+// 		res.WGPatientBrochure = wgBrochures[0].FDData
+// 	}
+
+// 	// SC Patient Brochure
+// 	var scBrochures []model.ListWGPatientBrochureModel
+// 	if err := db.Raw(query.ListSCPatientBrochureSQL, 4, reqVal.ScancenterId).Scan(&scBrochures).Error; err != nil {
+// 		log.Error("Error fetching SC brochure: " + err.Error())
+// 		res.Status = false
+// 		return res
+// 	}
+// 	if len(scBrochures) > 0 {
+// 		res.SCBrochureAccessStatus = scBrochures[0].FDAccessData
+// 		res.SCPatientBrochure = scBrochures[0].FDData
+// 	}
+
+// 	return res
+// }
+
+// func UpdatePatientConsentService(db *gorm.DB, reqVal model.UpdatePatientBroucherReq, idValue int) model.UpdatePatientBroucherResponse {
+// 	log := logger.InitLogger()
+
+// 	tx := db.Begin()
+// 	if tx.Error != nil {
+// 		log.Printf("ERROR: Failed to begin transaction: %v\n", tx.Error)
+// 		return model.UpdatePatientBroucherResponse{
+// 			Status:  false,
+// 			Message: "Something Went Wrong, Try Again",
+// 		}
+// 	}
+
+// 	defer func() {
+// 		if r := recover(); r != nil {
+// 			log.Error("ERROR: Recovered from panic, rolling back transaction:", r)
+// 			tx.Rollback()
+// 		}
+// 	}()
+
+// 	if reqVal.ScancenterId == 0 { //Wellthgreen Patient Brochure need to Handle
+// 		var wgBrochures []model.ListWGPatientBrochureModel
+// 		if err := tx.Raw(query.ListWGPatientBrochureSQL, 3).Scan(&wgBrochures).Error; err != nil {
+// 			log.Error("Error fetching WG brochure: " + err.Error())
+// 			return model.UpdatePatientBroucherResponse{
+// 				Status:  false,
+// 				Message: "Something Went Wrong, Try Again",
+// 			}
+// 		}
+
+// 		if len(wgBrochures) > 0 { //Need to Update the Brochure
+// 			UpdateWGBrochureErr := tx.Exec(query.UpdateWGPatientBrochureSQL, reqVal.Brochure, 3).Error
+// 			if UpdateWGBrochureErr != nil {
+// 				log.Error("Error updating WG brochure: " + UpdateWGBrochureErr.Error())
+// 				return model.UpdatePatientBroucherResponse{
+// 					Status:  false,
+// 					Message: "Something Went Wrong, Try Again",
+// 				}
+// 			}
+
+// 			errTrans := tx.Exec(query.InsertTransactionDataSQL, 38, 3, int(idValue), "Wellthgreen Patient Consent Updated!").Error
+// 			if errTrans != nil {
+// 				log.Printf("ERROR: Failed to Transaction History: %v\n", errTrans)
+// 				tx.Rollback()
+// 				return model.UpdatePatientBroucherResponse{
+// 					Status:  false,
+// 					Message: "Something Went Wrong, Try Again",
+// 				}
+// 			}
+
+// 		} else { //Need to Add the Brochure
+// 			AddWGBrochureErr := tx.Exec(query.InsertWGPatientBrochureSQL, 3, reqVal.Brochure).Error
+// 			if AddWGBrochureErr != nil {
+// 				log.Error("Error adding WG brochure: " + AddWGBrochureErr.Error())
+// 				return model.UpdatePatientBroucherResponse{
+// 					Status:  false,
+// 					Message: "Something Went Wrong, Try Again",
+// 				}
+// 			}
+
+// 			errTrans := tx.Exec(query.InsertTransactionDataSQL, 38, 3, int(idValue), "Wellthgreen Patient Consent Added!").Error
+// 			if errTrans != nil {
+// 				log.Printf("ERROR: Failed to Transaction History: %v\n", errTrans)
+// 				tx.Rollback()
+// 				return model.UpdatePatientBroucherResponse{
+// 					Status:  false,
+// 					Message: "Something Went Wrong, Try Again",
+// 				}
+// 			}
+// 		}
+
+// 	} else { //Scan Center Patient Brochure need to Handle
+// 		var scBrochures []model.ListWGPatientBrochureModel
+// 		if err := tx.Raw(query.ListSCPatientBrochureSQL, 4, reqVal.ScancenterId).Scan(&scBrochures).Error; err != nil {
+// 			log.Error("Error fetching SC brochure: " + err.Error())
+// 			return model.UpdatePatientBroucherResponse{
+// 				Status:  false,
+// 				Message: "Something Went Wrong, Try Again",
+// 			}
+// 		}
+
+// 		if len(scBrochures) > 0 { //Need to Update the Brochure
+// 			UpdatescBrochureErr := tx.Exec(
+// 				query.UpdatescPatientBrochureSQL,
+// 				reqVal.Brochure,
+// 				reqVal.AccessStatus,
+// 				4,
+// 				reqVal.ScancenterId,
+// 			).Error
+// 			if UpdatescBrochureErr != nil {
+// 				log.Error("Error updating SC brochure: " + UpdatescBrochureErr.Error())
+// 				return model.UpdatePatientBroucherResponse{
+// 					Status:  false,
+// 					Message: "Something Went Wrong, Try Again",
+// 				}
+// 			}
+
+// 			errTrans := tx.Exec(query.InsertTransactionDataSQL, 39, reqVal.ScancenterId, int(idValue), "Scan Center Patient Consent Updated!").Error
+// 			if errTrans != nil {
+// 				log.Printf("ERROR: Failed to Transaction History: %v\n", errTrans)
+// 				tx.Rollback()
+// 				return model.UpdatePatientBroucherResponse{
+// 					Status:  false,
+// 					Message: "Something Went Wrong, Try Again",
+// 				}
+// 			}
+// 		} else { // Need to Add the Brochure
+// 			AddscBrochureErr := tx.Exec(
+// 				query.InsertscPatientBrochureSQL,
+// 				4,
+// 				reqVal.ScancenterId,
+// 				reqVal.Brochure,
+// 				reqVal.AccessStatus,
+// 			).Error
+// 			if AddscBrochureErr != nil {
+// 				log.Error("Error adding SC brochure: " + AddscBrochureErr.Error())
+// 				return model.UpdatePatientBroucherResponse{
+// 					Status:  false,
+// 					Message: "Something Went Wrong, Try Again",
+// 				}
+// 			}
+
+// 			errTrans := tx.Exec(query.InsertTransactionDataSQL, 39, reqVal.ScancenterId, int(idValue), "Scan Center Patient Consent Added!").Error
+// 			if errTrans != nil {
+// 				log.Printf("ERROR: Failed to Transaction History: %v\n", errTrans)
+// 				tx.Rollback()
+// 				return model.UpdatePatientBroucherResponse{
+// 					Status:  false,
+// 					Message: "Something Went Wrong, Try Again",
+// 				}
+// 			}
+// 		}
+
+// 	}
+
+// 	if err := tx.Commit().Error; err != nil {
+// 		log.Printf("ERROR: Failed to commit transaction: %v\n", err)
+// 		tx.Rollback()
+// 		return model.UpdatePatientBroucherResponse{
+// 			Status:  false,
+// 			Message: "Something Went Wrong, Try Again",
+// 		}
+// 	}
+
+// 	return model.UpdatePatientBroucherResponse{
+// 		Status:  true,
+// 		Message: "Successfully Updated the Brochure",
+// 	}
+// }

--- a/controllers/Authentication/LoginController.go
+++ b/controllers/Authentication/LoginController.go
@@ -76,6 +76,7 @@ func VerifyOTPController() gin.HandlerFunc {
 			response["token"] = resVal.Token
 			response["RoleType"] = resVal.RoleType
 			response["PasswordStatus"] = resVal.PasswordStatus
+			response["ScancenterId"] = resVal.ScanCenterId
 		}
 
 		c.JSON(http.StatusOK, gin.H{

--- a/controllers/UserService/WellthgreenFormsControllers.go
+++ b/controllers/UserService/WellthgreenFormsControllers.go
@@ -1,0 +1,355 @@
+package controllers
+
+import (
+	service "AuthenticationService/Service/UserService"
+	db "AuthenticationService/internal/DB"
+	accesstoken "AuthenticationService/internal/Helper/AccessToken"
+	hashapi "AuthenticationService/internal/Helper/HashAPI"
+	helper "AuthenticationService/internal/Helper/RequestHandler"
+	model "AuthenticationService/internal/Model/UserService"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func ListPatientConsentController() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		idValue, idExists := c.Get("id")
+		roleIdValue, roleIdExists := c.Get("roleId")
+
+		if !idExists || !roleIdExists {
+			// Handle error: ID is missing from context (e.g., middleware didn't set it)
+			c.JSON(http.StatusUnauthorized, gin.H{ // Or StatusInternalServerError depending on why it's missing
+				"status":  false,
+				"message": "User ID, RoleID, Branch ID not found in request context.",
+			})
+			return // Stop processing
+		}
+
+		data, ok := helper.GetRequestBody[model.ListPatientConsentReq](c, true)
+		if !ok {
+			return
+		}
+
+		dbConn, sqlDB := db.InitDB()
+		defer sqlDB.Close()
+
+		resVal := service.ListPatientConsentService(dbConn, data)
+		token := accesstoken.CreateToken(idValue, roleIdValue)
+
+		payload := map[string]interface{}{
+			"data": resVal,
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"data":  hashapi.Encrypt(payload, true, token),
+			"token": token,
+		})
+
+	}
+}
+
+func ListPatientBrochureControllers() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		idValue, idExists := c.Get("id")
+		roleIdValue, roleIdExists := c.Get("roleId")
+
+		if !idExists || !roleIdExists {
+			// Handle error: ID is missing from context (e.g., middleware didn't set it)
+			c.JSON(http.StatusUnauthorized, gin.H{ // Or StatusInternalServerError depending on why it's missing
+				"status":  false,
+				"message": "User ID, RoleID, Branch ID not found in request context.",
+			})
+			return // Stop processing
+		}
+
+		data, ok := helper.GetRequestBody[model.ListPatientBrochureReq](c, true)
+		if !ok {
+			return
+		}
+
+		dbConn, sqlDB := db.InitDB()
+		defer sqlDB.Close()
+
+		resVal := service.ListPatientBrochureService(dbConn, data, 1, 2)
+		token := accesstoken.CreateToken(idValue, roleIdValue)
+
+		payload := map[string]interface{}{
+			"status":                 resVal.Status,
+			"WGPatientBrochure":      resVal.WGPatientBrochure,
+			"SCBrochureAccessStatus": resVal.SCBrochureAccessStatus,
+			"SCPatientBrochure":      resVal.SCPatientBrochure,
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"data":  hashapi.Encrypt(payload, true, token),
+			"token": token,
+		})
+
+	}
+}
+
+func UpdatePatientBrochureControllers() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		idValue, idExists := c.Get("id")
+		roleIdValue, roleIdExists := c.Get("roleId")
+
+		if !idExists || !roleIdExists {
+			// Handle error: ID is missing from context (e.g., middleware didn't set it)
+			c.JSON(http.StatusUnauthorized, gin.H{ // Or StatusInternalServerError depending on why it's missing
+				"status":  false,
+				"message": "User ID, RoleID, Branch ID not found in request context.",
+			})
+			return // Stop processing
+		}
+
+		//Request Should Be Encrypt
+		data, ok := helper.GetRequestBody[model.UpdatePatientBroucherReq](c, true)
+		if !ok {
+			return
+		}
+
+		dbConn, sqlDB := db.InitDB()
+		defer sqlDB.Close()
+
+		resVal := service.UpdatePatientBrochureService(dbConn, data, int(idValue.(float64)), 1, 2, 36, 37)
+		token := accesstoken.CreateToken(idValue, roleIdValue)
+
+		c.JSON(http.StatusOK, gin.H{
+			"data":  hashapi.Encrypt(resVal, true, token),
+			"token": token,
+		})
+
+	}
+}
+
+func ListPatientConsentControllers() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		idValue, idExists := c.Get("id")
+		roleIdValue, roleIdExists := c.Get("roleId")
+
+		if !idExists || !roleIdExists {
+			// Handle error: ID is missing from context (e.g., middleware didn't set it)
+			c.JSON(http.StatusUnauthorized, gin.H{ // Or StatusInternalServerError depending on why it's missing
+				"status":  false,
+				"message": "User ID, RoleID, Branch ID not found in request context.",
+			})
+			return // Stop processing
+		}
+
+		data, ok := helper.GetRequestBody[model.ListPatientBrochureReq](c, true)
+		if !ok {
+			return
+		}
+
+		dbConn, sqlDB := db.InitDB()
+		defer sqlDB.Close()
+
+		resVal := service.ListPatientBrochureService(dbConn, data, 3, 4)
+		token := accesstoken.CreateToken(idValue, roleIdValue)
+
+		payload := map[string]interface{}{
+			"status":                 resVal.Status,
+			"WGPatientBrochure":      resVal.WGPatientBrochure,
+			"SCBrochureAccessStatus": resVal.SCBrochureAccessStatus,
+			"SCPatientBrochure":      resVal.SCPatientBrochure,
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"data":  hashapi.Encrypt(payload, true, token),
+			"token": token,
+		})
+
+	}
+}
+
+func UpdatePatientConsentControllers() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		idValue, idExists := c.Get("id")
+		roleIdValue, roleIdExists := c.Get("roleId")
+
+		if !idExists || !roleIdExists {
+			// Handle error: ID is missing from context (e.g., middleware didn't set it)
+			c.JSON(http.StatusUnauthorized, gin.H{ // Or StatusInternalServerError depending on why it's missing
+				"status":  false,
+				"message": "User ID, RoleID, Branch ID not found in request context.",
+			})
+			return // Stop processing
+		}
+
+		//Request Should Be Encrypt
+		data, ok := helper.GetRequestBody[model.UpdatePatientBroucherReq](c, true)
+		if !ok {
+			return
+		}
+
+		dbConn, sqlDB := db.InitDB()
+		defer sqlDB.Close()
+
+		resVal := service.UpdatePatientBrochureService(dbConn, data, int(idValue.(float64)), 3, 4, 38, 39)
+		token := accesstoken.CreateToken(idValue, roleIdValue)
+
+		c.JSON(http.StatusOK, gin.H{
+			"data":  hashapi.Encrypt(resVal, true, token),
+			"token": token,
+		})
+
+	}
+}
+
+func ListTrainingMaterialGuideControllers() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		idValue, idExists := c.Get("id")
+		roleIdValue, roleIdExists := c.Get("roleId")
+
+		if !idExists || !roleIdExists {
+			// Handle error: ID is missing from context (e.g., middleware didn't set it)
+			c.JSON(http.StatusUnauthorized, gin.H{ // Or StatusInternalServerError depending on why it's missing
+				"status":  false,
+				"message": "User ID, RoleID, Branch ID not found in request context.",
+			})
+			return // Stop processing
+		}
+
+		data, ok := helper.GetRequestBody[model.ListPatientBrochureReq](c, true)
+		if !ok {
+			return
+		}
+
+		dbConn, sqlDB := db.InitDB()
+		defer sqlDB.Close()
+
+		resVal := service.ListPatientBrochureService(dbConn, data, 5, 6)
+		token := accesstoken.CreateToken(idValue, roleIdValue)
+
+		payload := map[string]interface{}{
+			"status":                 resVal.Status,
+			"WGPatientBrochure":      resVal.WGPatientBrochure,
+			"SCBrochureAccessStatus": resVal.SCBrochureAccessStatus,
+			"SCPatientBrochure":      resVal.SCPatientBrochure,
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"data":  hashapi.Encrypt(payload, true, token),
+			"token": token,
+		})
+
+	}
+}
+
+func UpdateTrainingMaterialGuideControllers() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		idValue, idExists := c.Get("id")
+		roleIdValue, roleIdExists := c.Get("roleId")
+
+		if !idExists || !roleIdExists {
+			// Handle error: ID is missing from context (e.g., middleware didn't set it)
+			c.JSON(http.StatusUnauthorized, gin.H{ // Or StatusInternalServerError depending on why it's missing
+				"status":  false,
+				"message": "User ID, RoleID, Branch ID not found in request context.",
+			})
+			return // Stop processing
+		}
+
+		//Request Should Be Encrypt
+		data, ok := helper.GetRequestBody[model.UpdatePatientBroucherReq](c, true)
+		if !ok {
+			return
+		}
+
+		dbConn, sqlDB := db.InitDB()
+		defer sqlDB.Close()
+
+		resVal := service.UpdatePatientBrochureService(dbConn, data, int(idValue.(float64)), 5, 6, 40, 41)
+		token := accesstoken.CreateToken(idValue, roleIdValue)
+
+		c.JSON(http.StatusOK, gin.H{
+			"data":  hashapi.Encrypt(resVal, true, token),
+			"token": token,
+		})
+
+	}
+}
+
+func ListTechnicianConsentControllers() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		idValue, idExists := c.Get("id")
+		roleIdValue, roleIdExists := c.Get("roleId")
+
+		if !idExists || !roleIdExists {
+			// Handle error: ID is missing from context (e.g., middleware didn't set it)
+			c.JSON(http.StatusUnauthorized, gin.H{ // Or StatusInternalServerError depending on why it's missing
+				"status":  false,
+				"message": "User ID, RoleID, Branch ID not found in request context.",
+			})
+			return // Stop processing
+		}
+
+		data, ok := helper.GetRequestBody[model.ListPatientBrochureReq](c, true)
+		if !ok {
+			return
+		}
+
+		dbConn, sqlDB := db.InitDB()
+		defer sqlDB.Close()
+
+		resVal := service.ListPatientBrochureService(dbConn, data, 7, 8)
+		token := accesstoken.CreateToken(idValue, roleIdValue)
+
+		payload := map[string]interface{}{
+			"status":                 resVal.Status,
+			"WGPatientBrochure":      resVal.WGPatientBrochure,
+			"SCBrochureAccessStatus": resVal.SCBrochureAccessStatus,
+			"SCPatientBrochure":      resVal.SCPatientBrochure,
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"data":  hashapi.Encrypt(payload, true, token),
+			"token": token,
+		})
+
+	}
+}
+
+func UpdateTechnicianConsentControllers() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		idValue, idExists := c.Get("id")
+		roleIdValue, roleIdExists := c.Get("roleId")
+
+		if !idExists || !roleIdExists {
+			// Handle error: ID is missing from context (e.g., middleware didn't set it)
+			c.JSON(http.StatusUnauthorized, gin.H{ // Or StatusInternalServerError depending on why it's missing
+				"status":  false,
+				"message": "User ID, RoleID, Branch ID not found in request context.",
+			})
+			return // Stop processing
+		}
+
+		//Request Should Be Encrypt
+		data, ok := helper.GetRequestBody[model.UpdatePatientBroucherReq](c, true)
+		if !ok {
+			return
+		}
+
+		dbConn, sqlDB := db.InitDB()
+		defer sqlDB.Close()
+
+		resVal := service.UpdatePatientBrochureService(dbConn, data, int(idValue.(float64)), 7, 8, 42, 43)
+		token := accesstoken.CreateToken(idValue, roleIdValue)
+
+		c.JSON(http.StatusOK, gin.H{
+			"data":  hashapi.Encrypt(resVal, true, token),
+			"token": token,
+		})
+
+	}
+}

--- a/internal/Model/Appointment/IntakeFormModel.go
+++ b/internal/Model/Appointment/IntakeFormModel.go
@@ -14,6 +14,7 @@ type AddIntakeFormReq struct {
 	CategoryId      int               `json:"categoryId" mapstructure:"categoryId"`
 	AppointmentId   int               `json:"appointmentId" binding:"required" mapstructure:"appointmentId"`
 	Answers         []AnswersReqModel `json:"answers" binding:"required" mapstructure:"answers"`
+	Consent         string            `json:"consent" binding:"required" mapstructure:"consent"`
 	OverrideRequest bool              `json:"overriderequest" mapstructure:"overriderequest"`
 }
 
@@ -75,6 +76,11 @@ type AduitModel struct {
 	CreatedAt   string `json:"refTHTime" gorm:"column:refTHTime"`
 	UserId      int    `json:"refUserId" gorm:"column:refUserId"`
 	THActionBy  int    `json:"refTHActionBy" gorm:"column:refTHActionBy"`
+}
+
+type TechnicianModel struct {
+	FirstName string `json:"refUserFirstName" gorm:"column:refUserFirstName"`
+	CustId    string `json:"refUserCustId" gorm:"column:refUserCustId"`
 }
 
 type PatientReq struct {

--- a/internal/Model/Authentication/LoginModel.go
+++ b/internal/Model/Authentication/LoginModel.go
@@ -24,6 +24,11 @@ type LoginResponse struct {
 	Token          string `json:"token"`
 	Email          string `json:"email"`
 	PasswordStatus bool   `json:"passwordStatus"`
+	ScanCenterId   int    `json:"scanCenterId"`
+}
+
+type ScanCenterStruct struct {
+	RefSCId int `json:"refSCId" gorm:"column:refSCId"`
 }
 
 type AdminLoginModel struct {
@@ -63,4 +68,5 @@ type VerifyOTP struct {
 
 type UserChnagePasswordReq struct {
 	Password string `json:"password" binding:"required" mapstructure:"password"`
+	Consent  string `json:"consent" mapstructure:"consent"`
 }

--- a/internal/Model/UserService/WellthgreenFormsModel.go
+++ b/internal/Model/UserService/WellthgreenFormsModel.go
@@ -1,0 +1,39 @@
+package model
+
+type ListPatientBrochureReq struct {
+	ScancenterId int `json:"scancenterId" mapstructure:"scancenterId"`
+}
+
+type ListPatientConsentReq struct {
+	ScanCenterId []int `json:"scancenterId" binding:"required"`
+}
+
+type ListPatientConsent struct {
+	Consent string `json:"refAppointmentConsent" gorm:"column:refAppointmentConsent"`
+}
+
+type ListWGPatientBrochureModel struct {
+	FDId         int    `json:"refFDId" gorm:"column:refFDId"`
+	FTId         int    `json:"refFTId" gorm:"column:refFTId"`
+	SCId         int    `json:"refSCId" gorm:"column:refSCId"`
+	FDData       string `json:"refFDData" gorm:"column:refFDData"`
+	FDAccessData bool   `json:"refFDAccessData" gorm:"column:refFDAccessData"`
+}
+
+type ListPatientBrochureRes struct {
+	Status                 bool   `json:"status"`
+	WGPatientBrochure      string `json:"refWGPatientData"`
+	SCBrochureAccessStatus bool   `json:"SCAccessStatus"`
+	SCPatientBrochure      string `json:"refSCPatientData"`
+}
+
+type UpdatePatientBroucherReq struct {
+	Brochure     string `json:"data" binding:"required" mapstructure:"data"`
+	ScancenterId int    `json:"scancenterId" mapstructure:"scancenterId"`
+	AccessStatus bool   `json:"accessStatus" mapstructure:"accessStatus"`
+}
+
+type UpdatePatientBroucherResponse struct {
+	Status  bool   `json:"status"`
+	Message string `json:"message"`
+}

--- a/main.go
+++ b/main.go
@@ -126,6 +126,11 @@ func main() {
 	routesUser.InitWellthgreenPerformingProviderRoutes(r)
 
 	fmt.Println()
+	fmt.Println("=================Wellthgreen Form=================")
+	fmt.Println()
+	routesUser.InitWellthgreenFormsRoutes(r)
+
+	fmt.Println()
 	fmt.Println("*****************ProfileService*****************")
 	fmt.Println()
 

--- a/query/Appointment/IntakeFormQuery.go
+++ b/query/Appointment/IntakeFormQuery.go
@@ -55,7 +55,8 @@ var UpdateAppointment = `
 UPDATE
   appointment."refAppointments"
 SET
-  "refCategoryId" = ?
+  "refCategoryId" = ?,
+  "refAppointmentConsent" = ?
 WHERE
   "refAppointmentId" = ?
 `
@@ -125,6 +126,15 @@ FROM
   aduit."refTransHistory"
 WHERE
   "transTypeId" IN (23, 24);
+`
+
+var TechnicianUserSQL = `
+SELECT
+  *
+FROM
+  public."Users"
+WHERE
+  "refUserId" = $1
 `
 
 var GetTextContent = `

--- a/query/Authentication/ForgetPasswordQuery.go
+++ b/query/Authentication/ForgetPasswordQuery.go
@@ -14,7 +14,8 @@ var UpdateUserDataSQL = `
 UPDATE
   public."Users"
 SET
-  "refUserAgreementStatus" = ?
+  "refUserAgreementStatus" = ?,
+  "refUserConsent" = ?
 WHERE
   "refUserId" = ?
 `

--- a/query/Authentication/LoginQuery.go
+++ b/query/Authentication/LoginQuery.go
@@ -29,6 +29,15 @@ var DeleteOTPSQL = `
 DELETE FROM tempotp."usersOTP" WHERE "refUserId" = ? AND "TOTPtype" = ?;
 `
 
+var ScanCenterIdSQL = `
+SELECT
+  *
+FROM
+  map."refScanCenterMap"
+WHERE
+  "refUserId" = ?
+`
+
 var CreateOTPSQL = `
 INSERT INTO tempotp."usersOTP" (
   "refUserId",

--- a/query/UserService/WellthgreenFormsQuery.go
+++ b/query/UserService/WellthgreenFormsQuery.go
@@ -1,0 +1,69 @@
+package query
+
+var ListPatientConsentSQL = `
+SELECT
+  "refAppointmentId",
+  "refAppointmentConsent"
+FROM
+  appointment."refAppointments"
+WHERE
+  "refAppointmentId" = ANY ($1)
+`
+
+var ListWGPatientBrochureSQL = `
+SELECT
+  *
+FROM
+  forms."formsData"
+WHERE
+  "refFTId" = $1
+`
+
+var ListSCPatientBrochureSQL = `
+SELECT
+  *
+FROM
+  forms."formsData"
+WHERE
+  "refFTId" = $1
+  AND "refSCId" = $2
+`
+
+var InsertWGPatientBrochureSQL = `
+INSERT INTO
+  forms."formsData" ("refFTId", "refFDData")
+VALUES
+  ($1, $2)
+`
+
+var InsertscPatientBrochureSQL = `
+INSERT INTO
+  forms."formsData" (
+    "refFTId",
+    "refSCId",
+    "refFDData",
+    "refFDAccessData"
+  )
+VALUES
+  ($1, $2, $3, $4);
+`
+
+var UpdateWGPatientBrochureSQL = `
+UPDATE
+  forms."formsData"
+SET
+  "refFDData" = $1
+WHERE
+  "refFTId" = $2;
+`
+
+var UpdatescPatientBrochureSQL = `
+UPDATE
+  forms."formsData"
+SET
+  "refFDData" = $1,
+  "refFDAccessData" = $2
+WHERE
+  "refFTId" = $3
+  AND "refSCId" = $4
+`

--- a/routes/UserService/WellthgreenFormsRoutes.go
+++ b/routes/UserService/WellthgreenFormsRoutes.go
@@ -1,0 +1,21 @@
+package routes
+
+import (
+	controllers "AuthenticationService/controllers/UserService"
+	accesstoken "AuthenticationService/internal/Helper/AccessToken"
+
+	"github.com/gin-gonic/gin"
+)
+
+func InitWellthgreenFormsRoutes(router *gin.Engine) {
+	route := router.Group("/api/v1/wellgreenforms")
+	route.POST("/listPatientconsent", accesstoken.JWTMiddleware(), controllers.ListPatientConsentController())
+	route.POST("/patientBrochure/list", accesstoken.JWTMiddleware(), controllers.ListPatientBrochureControllers())
+	route.PATCH("/patientBrochure/update", accesstoken.JWTMiddleware(), controllers.UpdatePatientBrochureControllers())
+	route.POST("/patientconsent/list", accesstoken.JWTMiddleware(), controllers.ListPatientConsentControllers())
+	route.PATCH("/patientconsent/update", accesstoken.JWTMiddleware(), controllers.UpdatePatientConsentControllers())
+	route.POST("/trainingmaterialguide/list", accesstoken.JWTMiddleware(), controllers.ListTrainingMaterialGuideControllers())
+	route.PATCH("/trainingmaterialguide/update", accesstoken.JWTMiddleware(), controllers.UpdateTrainingMaterialGuideControllers())
+	route.POST("/technicianconsent/list", accesstoken.JWTMiddleware(), controllers.ListTechnicianConsentControllers())
+	route.PATCH("/technicianconsent/update", accesstoken.JWTMiddleware(), controllers.UpdateTechnicianConsentControllers())
+}


### PR DESCRIPTION
These code changes allow the addition of Brochure, Consent, Tech Guidelines, and Tech Consent documents from Wellthgreen. Scan Center Admins can either use the default Wellthgreen documents or upload their own versions. Additionally, when a patient fills out the intake form, their consent is saved, and the corresponding brochure is previewed. Tech Guidelines are also previewed, and the appropriate consent is displayed during patient signup.